### PR TITLE
Added support for methods, @ keyword in parameters list and fat arrow

### DIFF
--- a/src/languages/CoffeeScript.js
+++ b/src/languages/CoffeeScript.js
@@ -37,7 +37,7 @@ define(function (require, exports, module) {
      * @returns {Array}   List of outline entries.
      */
     function getOutlineList(lines, showArguments, showUnnamed) {
-        var regex = /(([\w\$]*)?\s*=)?\s*(\([\w\$,.'"= ]*\))?\s*->/g;
+        var regex = /(([\w\$]*)?\s*(?:=|:))?\s*(\([\w\$@,.'"= ]*\))?\s*(?:->|=>)/g;
         var result = [];
         lines.forEach(function (line, index) {
             var match = regex.exec(line);


### PR DESCRIPTION
I slightly improved the regular expression to also match fat arrow function definitions, allow the @ keyword in the parameters list and return methods names instead of treating them as lambdas.
This results in more matches and less nameless functions.