### PR TITLE
Improved XML elements detection and fixed some issues

### DIFF
--- a/src/languages/CSS.js
+++ b/src/languages/CSS.js
@@ -36,6 +36,7 @@ define(function (require, exports, module) {
     function getOutlineList(lines) {
         var regex =  /([^\r\n,{}]+)((?=[^}]*\{)|\s*\{)/g;
         var result = [];
+        lines = lines.join("\n").replace(/(\n*)\{/g, "{$1").split("\n");
         lines.forEach(function (line, index) {
             var match = regex.exec(line);
             while (match !== null) {

--- a/src/languages/XML.js
+++ b/src/languages/XML.js
@@ -55,7 +55,7 @@ define(function (require, exports, module) {
     function getOutlineList(lines, showArguments) {
         var regex;
         if (showArguments) {
-            regex = /^([\t ]*)<([a-zA-Z:_][a-zA-Z0-9:_\-\.]*)( (.*(id|class)=(["'])([\w\- ]+)\6)?.*)?>/g;
+            regex = /^([\t ]*)<([a-zA-Z:_][a-zA-Z0-9:_\-\.]*)(?: (?:(?:(?:"(?:(?:\\")|[^\n\r"])*")|(?:'(?:(?:\\')|[^\n\r'])*')|[^\n\r<>"'])*(id|class)=(["'])([\w\- ]+)\4)?.*)?>/g;
         } else {
             regex = /^([\t ]*)<([a-zA-Z:_][a-zA-Z0-9:_\-\.]*).*>/g;
         }
@@ -65,8 +65,8 @@ define(function (require, exports, module) {
             while (match !== null) {
                 var whitespace = match[1];
                 var name = match[2].trim();
-                var type = (match[5] || "").trim();
-                var args = (match[7] || "").trim();
+                var type = (match[3] || "").trim();
+                var args = (match[5] || "").trim();
                 var entry = _createListEntry(name, type, args, _getIndentationLevel(whitespace));
                 entry.line = index;
                 entry.ch = line.length;

--- a/src/languages/XML.js
+++ b/src/languages/XML.js
@@ -23,7 +23,7 @@ define(function (require, exports, module) {
             var typechar = type == "id" ? "#" : ".";
             var $arguments = $(document.createElement("span"));
             $arguments.addClass("outline-entry-xml-" + type);
-            $arguments.text(" " + typechar + args);
+            $arguments.text(" " + typechar + args.replace(/ /g, " " + typechar));
             $elements.push($arguments);
         }
         return {
@@ -55,9 +55,9 @@ define(function (require, exports, module) {
     function getOutlineList(lines, showArguments) {
         var regex;
         if (showArguments) {
-            regex = /^(\s*)<(\w+)[ (>)](.*(id|class)=[""]([\w- ]+)[""])?/g;
+            regex = /^([\t ]*)<([a-zA-Z:_][a-zA-Z0-9:_\-\.]*)( (.*(id|class)=(["'])([\w\- ]+)\6)?.*)?>/g;
         } else {
-            regex = /^(\s*)<(\w+)[ (>)]/g;
+            regex = /^([\t ]*)<([a-zA-Z:_][a-zA-Z0-9:_\-\.]*).*>/g;
         }
         var result = [];
         lines.forEach(function (line, index) {
@@ -65,8 +65,8 @@ define(function (require, exports, module) {
             while (match !== null) {
                 var whitespace = match[1];
                 var name = match[2].trim();
-                var type = (match[4] || "").trim();
-                var args = (match[5] || "").trim();
+                var type = (match[5] || "").trim();
+                var args = (match[7] || "").trim();
                 var entry = _createListEntry(name, type, args, _getIndentationLevel(whitespace));
                 entry.line = index;
                 entry.ch = line.length;

--- a/src/languages/XML.js
+++ b/src/languages/XML.js
@@ -42,7 +42,7 @@ define(function (require, exports, module) {
         for (var i = 0; i < indentSize; i++) {
             tmpSpaces += " ";
         }
-        whitespace.replace(/\t/, tmpSpaces);
+        whitespace = whitespace.replace(/\t/g, tmpSpaces);
         return (whitespace.length / indentSize) | 0;
     }
 


### PR DESCRIPTION
I improved the regular expression to match most common XML elements.
Unicode characters are still unsupported.
I slightly improved the output to show `.` before each class instead of just the first one.
The same applies to `#`, but that shouldn't normally happen.
I fixed an issue with tabs-indented files, where nesting wouldn't be rendered properly.
I fixed an issue where the last `id` or `class` of the line would show up in the outline next to the first element of that line, regardless of it actually belonging to that element or not.
I also fixed issue #5 where CSS selectors with curly braces on the subsequent line wouldn't be detected.