### PR TITLE
[Fix] Patch PHP lexer

### DIFF
--- a/src/lexers/PHPLexer.js
+++ b/src/lexers/PHPLexer.js
@@ -111,7 +111,7 @@ define(function (require, exports, module) {
                             } else {
                                 ref.name = w;
                             }
-                            ref.modifier = modifier || 'public';
+                            ref.modifier = modifier || "public";
                             break;
                         case "class":
                             ns.push(w);

--- a/test/PHPLexerSpec.js
+++ b/test/PHPLexerSpec.js
@@ -46,5 +46,11 @@ define(function (require) {
             expect(result[1].name).toEqual("myClass::myFunc");
             expect(result[1].type).toEqual("function");
         });
+
+        it("detects comments", function () {
+            var test = require("text!example/php/comment.php");
+            var result = Lexer.parse(test);
+            expect(result.length).toEqual(0);
+        });
     });
 });

--- a/test/PHPLexerSpec.js
+++ b/test/PHPLexerSpec.js
@@ -29,6 +29,7 @@ define(function (require) {
             expect(result[1].line).toEqual(2);
             expect(result[1].name).toEqual("myClass::myFunc");
             expect(result[1].type).toEqual("function");
+            expect(result[1].modifier).toEqual("private");
         });
 
         it("detects function arguments declared on seperate lines", function () {

--- a/test/example/php/comment.php
+++ b/test/example/php/comment.php
@@ -1,0 +1,9 @@
+<?php
+//function abc() {
+//    return null;
+//}
+/*
+function cde() {
+    return null;
+}
+*/


### PR DESCRIPTION
Further improve the PHP lexer:
1. Definitions in comments are ignored.
2. Modifier beside a function is now detected.

Test cases are included.
