### PR TITLE
split php source to array to speed up lexing, closes #70

### DIFF
--- a/src/lexers/PHPLexer.js
+++ b/src/lexers/PHPLexer.js
@@ -180,9 +180,10 @@ define(function (require, exports, module) {
             .addRule(/\r?\n/, function () {
                 line += 1;
             });
-        lexer.setInput(source);
         // parse the code to the end of the source.
-        while (lexer.index < source.length - 1) {
+        source = source.split('\n');
+        for (var i =0, l = source.length; i<l; i++) {
+            lexer.setInput(source[i]);
             lexer.lex();
         }
         return results;

--- a/src/lexers/PHPLexer.js
+++ b/src/lexers/PHPLexer.js
@@ -175,16 +175,14 @@ define(function (require, exports, module) {
                 }
             })
             // other terms are ignored.
-            .addRule(/./, ignored)
-            // line number increases.
-            .addRule(/\r?\n/, function () {
-                line += 1;
-            });
-        // parse the code to the end of the source.
+            .addRule(/./, ignored);
         source = source.split('\n');
+        // parse the code to the end of the source.
         for (var i =0, l = source.length; i<l; i++) {
             lexer.setInput(source[i]);
             lexer.lex();
+            // line number increases.
+            line += 1;
         }
         return results;
     }

--- a/src/lexers/PHPLexer.js
+++ b/src/lexers/PHPLexer.js
@@ -176,9 +176,9 @@ define(function (require, exports, module) {
             })
             // other terms are ignored.
             .addRule(/./, ignored);
-        source = source.split('\n');
+        source = source.split("\n");
         // parse the code to the end of the source.
-        for (var i =0, l = source.length; i<l; i++) {
+        for (var i = 0, l = source.length; i < l; i++) {
             lexer.setInput(source[i]);
             lexer.lex();
             // line number increases.


### PR DESCRIPTION
Significant decrease in parsing time, especially noticable in large files. When testing example file from #70 in Chrome 55, time decrease from 7s to 250ms and in Waterfox from 6.2s to 210ms