### PR TITLE
PHP Abstract Classes (fix #76)

### DIFF
--- a/src/lexers/PHPLexer.js
+++ b/src/lexers/PHPLexer.js
@@ -206,7 +206,7 @@ define(function (require, exports, module) {
             })
             .addRule(/;/, function () {
                 if (!literal && !comment) {
-                    if(peek(state) === "function" && isAbstract) {
+                    if (peek(state) === "function" && isAbstract) {
                         ns.pop();
                         isAbstract = false;
                     } else if (peek(state) === "class") {

--- a/src/lexers/PHPLexer.js
+++ b/src/lexers/PHPLexer.js
@@ -20,6 +20,7 @@ define(function (require, exports, module) {
         var modifier = null; // the modifier.
         var isStatic = false; // static flag.
         var isAbstract = false; // abstract flag.
+        var lastExtended = null;
         // helper function to peek an item from an array.
         var peek = function (array) {
             if (array.length > 0) {
@@ -95,7 +96,8 @@ define(function (require, exports, module) {
             .addRule(/extends/, function () {
                 if (!literal && !comment) {
                     if (peek(state) === "class") {
-                        state.pop();
+                        lastExtended = results.pop();
+                        state.push("extended");
                     }
                 }
             })
@@ -128,6 +130,12 @@ define(function (require, exports, module) {
                             break;
                         case "class":
                             ns.push(w);
+                            ref = peek(results);
+                            ref.name += "::" + w;
+                            break;
+                        case "extended":
+                            state.push("class");
+                            results.push(lastExtended);
                             ref = peek(results);
                             ref.name += "::" + w;
                             break;

--- a/src/lexers/PHPLexer.js
+++ b/src/lexers/PHPLexer.js
@@ -20,7 +20,9 @@ define(function (require, exports, module) {
         var modifier = null; // the modifier.
         var isStatic = false; // static flag.
         var isAbstract = false; // abstract flag.
-        var lastExtendsChild = null; // stores the results object of class that extends another
+        // stores the results object of class that extends another
+        // or implements an interface.
+        var lastChildClass = null;
         // helper function to peek an item from an array.
         var peek = function (array) {
             if (array.length > 0) {
@@ -92,12 +94,12 @@ define(function (require, exports, module) {
                     });
                 }
             })
-            // added support for extended classes
-            .addRule(/extends/, function () {
+            // add support for extended classes and interface implementations
+            .addRule(/extends|implements/, function () {
                 if (!literal && !comment) {
                     if (peek(state) === "class") {
-                        lastExtendsChild = results.pop();
-                        state.push("extended");
+                        lastChildClass = results.pop();
+                        state.push("inheriting");
                     }
                 }
             })
@@ -133,9 +135,9 @@ define(function (require, exports, module) {
                             ref = peek(results);
                             ref.name += "::" + w;
                             break;
-                        case "extended":
+                        case "inheriting":
                             state.push("class");
-                            results.push(lastExtendsChild);
+                            results.push(lastChildClass);
                             ref = peek(results);
                             ref.name += "::" + w;
                             break;

--- a/src/lexers/PHPLexer.js
+++ b/src/lexers/PHPLexer.js
@@ -20,7 +20,7 @@ define(function (require, exports, module) {
         var modifier = null; // the modifier.
         var isStatic = false; // static flag.
         var isAbstract = false; // abstract flag.
-        var lastExtended = null;
+        var lastExtendsChild = null; // stores the results object of class that extends another
         // helper function to peek an item from an array.
         var peek = function (array) {
             if (array.length > 0) {
@@ -96,7 +96,7 @@ define(function (require, exports, module) {
             .addRule(/extends/, function () {
                 if (!literal && !comment) {
                     if (peek(state) === "class") {
-                        lastExtended = results.pop();
+                        lastExtendsChild = results.pop();
                         state.push("extended");
                     }
                 }
@@ -135,7 +135,7 @@ define(function (require, exports, module) {
                             break;
                         case "extended":
                             state.push("class");
-                            results.push(lastExtended);
+                            results.push(lastExtendsChild);
                             ref = peek(results);
                             ref.name += "::" + w;
                             break;


### PR DESCRIPTION
Fixed PHP abstract classes support (#76).
Fixed PHP extended classes support.
Fixed support for PHP anonymous functions within other functions.
Fixed support for numbers in PHP class, function and variable names.
Fixed PHP static functions not appearing pointed