### PR TITLE
PHP parser improvements

### DIFF
--- a/src/languages/PHP.js
+++ b/src/languages/PHP.js
@@ -12,6 +12,8 @@ define(function (require, exports, module) {
      * @param   {string}  name     List entry name.
      * @param   {string}  args     Arguments as single string.
      * @param   {string}  vis      Visibility modifier.
+     * @param   {number}  level    Indentation level.
+     * @param   {boolean} isClass  Flag if entry is class.
      * @param   {boolean} isStatic Flag if entry is static.
      * @param   {number}  line     Line number.
      * @param   {number}  ch       Character number.

--- a/src/languages/PHP.js
+++ b/src/languages/PHP.js
@@ -17,8 +17,18 @@ define(function (require, exports, module) {
      * @param   {number}  ch       Character number.
      * @returns {object}  Entry object with an $html property.
      */
-    function _createListEntry(name, args, vis, isStatic, line, ch) {
+    function _createListEntry(name, args, vis, level, isClass, isStatic, line, ch) {
         var $elements = [];
+
+        var $indentation = $(document.createElement("span"));
+        $indentation.addClass("outline-entry-indent");
+        var interpunct = "";
+        for (var i = 0; i < level; i++) {
+            interpunct += "·";
+        }
+        $indentation.text(interpunct);
+        $elements.push($indentation);
+
         var $name = $(document.createElement("span"));
         $name.addClass("outline-entry-name");
         $name.text(name);
@@ -30,6 +40,9 @@ define(function (require, exports, module) {
         var classes = "outline-entry-php outline-entry-icon outline-entry-" + vis;
         if (isStatic) {
             classes += " outline-entry-static";
+        }
+        if (isClass) {
+            classes += " outline-entry-class";
         }
         return {
             name: name,
@@ -47,16 +60,21 @@ define(function (require, exports, module) {
      */
     function getOutlineList(text) {
         return Lexer.parse(text)
-            // ignore the classes definition.
-            .filter(function (it) {
-                return it.type === "function";
-            })
             // map code structure to html item.
             .map(function (it) {
+                var isClass = true;
+                // show arguments parenthesis only for functions
+                var argsToggle = "";
+                if (it.type === "function") {
+                    argsToggle = "(" + it.args.join(", ") + ")";
+                    isClass = false;
+                }
                 return _createListEntry(
                     it.name,
-                    "(" + it.args.join(", ") + ")",
+                    argsToggle,
                     it.modifier,
+                    it.level,
+                    isClass,
                     it.isStatic,
                     it.line,
                     0

--- a/src/lexers/PHPLexer.js
+++ b/src/lexers/PHPLexer.js
@@ -166,7 +166,7 @@ define(function (require, exports, module) {
                         if (ref.modifier === "unnamed") {
                             if (lastNamedFunction) {
                                 if (ns.length > 0) {
-                                    ref.name += "::"
+                                    ref.name += "::";
                                 }
                                 ref.name += lastNamedFunction + "::";
                             }

--- a/src/lexers/PHPLexer.js
+++ b/src/lexers/PHPLexer.js
@@ -227,6 +227,15 @@ define(function (require, exports, module) {
                     }
                 }
             })
+            // support for classes implementing multiple interfaces
+            .addRule(/,/, function () {
+                if (!literal && !comment) {
+                    if (peek(state) === "class") {
+                        state.pop();
+                        results.pop();
+                    }
+                }
+            })
             // other terms are ignored.
             .addRule(/./, ignored);
 

--- a/src/lexers/PHPLexer.js
+++ b/src/lexers/PHPLexer.js
@@ -51,6 +51,10 @@ define(function (require, exports, module) {
             })
             // ignore the comments.
             .addRule(/\/\/[^\n]*/, ignored)
+            // ignore strings (double quotes).
+            .addRule(/"((?:\\.|[^"\\])*)"/, ignored)
+            // ignore strings (single quotes).
+            .addRule(/'((?:\\.|[^'\\])*)'/, ignored)
             // detect abstract modifier, but treat it apart from the visibility modifiers
             .addRule(/public|protected|private|abstract/, function (w) {
                 if (w === "abstract") {
@@ -81,7 +85,7 @@ define(function (require, exports, module) {
             // when it encounters `class` and literal mode is off.
             // 1. push "class" into state array.
             // 2. create a class structure into results array.
-            .addRule(/class /, function () {
+            .addRule(/class/, function () {
                 if (!literal && !comment && ns.length === 0) {
                     state.push("class");
                     results.push({

--- a/src/lexers/PHPLexer.js
+++ b/src/lexers/PHPLexer.js
@@ -55,6 +55,8 @@ define(function (require, exports, module) {
             .addRule(/"((?:\\.|[^"\\])*)"/, ignored)
             // ignore strings (single quotes).
             .addRule(/'((?:\\.|[^'\\])*)'/, ignored)
+            // ignore execution operator (backticks).
+            .addRule(/`((?:\\.|[^`\\])*)`/, ignored)
             // detect abstract modifier, but treat it apart from the visibility modifiers
             .addRule(/public|protected|private|abstract/, function (w) {
                 if (w === "abstract") {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -276,6 +276,10 @@
 
 
 /* PHP */
+.outline-entry-php.outline-entry-class {
+    color: #d14747;
+    content: "\f3a0";
+}
 .outline-entry-php.outline-entry-private:before {
     color: #229bf4;
     content: "\f200";

--- a/test/PHPLexerSpec.js
+++ b/test/PHPLexerSpec.js
@@ -104,7 +104,7 @@ define(function (require) {
             ]);
         });
 
-        xit("detects multiple interfaces", function () {
+        it("detects multiple interfaces", function () {
             var test = require("text!example/php/multiple_interfaces.php");
             var result = Lexer.parse(test);
             expect(result).toEqual([

--- a/test/PHPLexerSpec.js
+++ b/test/PHPLexerSpec.js
@@ -21,15 +21,17 @@ define(function (require) {
             expect(result.length).toEqual(2);
 
             expect(result[0].line).toEqual(1);
-            expect(result[0].name).toEqual("::myClass");
+            expect(result[0].name).toEqual("myClass");
             expect(result[0].type).toEqual("class");
+            expect(result[0].level).toEqual(0);
 
             expect(result[1].args.length).toEqual(0);
             expect(result[1].isStatic).toEqual(false);
             expect(result[1].line).toEqual(2);
-            expect(result[1].name).toEqual("myClass::myFunc");
+            expect(result[1].name).toEqual("myFunc");
             expect(result[1].type).toEqual("function");
             expect(result[1].modifier).toEqual("private");
+            expect(result[1].level).toEqual(1);
         });
 
         it("detects function arguments declared on seperate lines", function () {
@@ -38,14 +40,16 @@ define(function (require) {
             expect(result.length).toEqual(2);
 
             expect(result[0].line).toEqual(1);
-            expect(result[0].name).toEqual("::myClass");
+            expect(result[0].name).toEqual("myClass");
             expect(result[0].type).toEqual("class");
+            expect(result[0].level).toEqual(0);
 
             expect(result[1].args.length).toEqual(2);
             expect(result[1].isStatic).toEqual(false);
             expect(result[1].line).toEqual(2);
-            expect(result[1].name).toEqual("myClass::myFunc");
+            expect(result[1].name).toEqual("myFunc");
             expect(result[1].type).toEqual("function");
+            expect(result[1].level).toEqual(1);
         });
 
         it("detects comments", function () {
@@ -60,44 +64,50 @@ define(function (require) {
             expect(result).toEqual([
                 {
                     type: "class",
-                    name: "::Child::IChild",
+                    name: "Child",
                     args: [],
                     modifier: "public",
+                    level: 0,
                     isStatic: false,
                     line: 1
                 }, {
                     type: "function",
-                    name: "Child::speak",
+                    name: "speak",
                     args: [],
                     modifier: "public",
+                    level: 1,
                     isStatic: false,
                     line: 2
                 }, {
                     type: "class",
-                    name: "::Child::BaseChild",
+                    name: "Child",
                     args: [],
                     modifier: "public",
+                    level: 0,
                     isStatic: false,
                     line: 5
                 }, {
                     type: "function",
-                    name: "Child::speak",
+                    name: "speak",
                     args: [],
                     modifier: "public",
+                    level: 1,
                     isStatic: false,
                     line: 6
                 }, {
                     type: "class",
-                    name: "::Child::BaseChild::IChild",
+                    name: "Child",
                     args: [],
                     modifier: "public",
+                    level: 0,
                     isStatic: false,
                     line: 9
                 }, {
                     type: "function",
-                    name: "Child::speak",
+                    name: "speak",
                     args: [],
                     modifier: "public",
+                    level: 1,
                     isStatic: false,
                     line: 10
                 }
@@ -110,16 +120,18 @@ define(function (require) {
             expect(result).toEqual([
                 {
                     type: "class",
-                    name: "::Child::IChild::IChild2",
+                    name: "Child",
                     args: [],
                     modifier: "public",
+                    level: 0,
                     isStatic: false,
                     line: 1
                 }, {
                     type: "function",
-                    name: "Child::speak",
+                    name: "speak",
                     args: [],
                     modifier: "public",
+                    level: 1,
                     isStatic: false,
                     line: 2
                 }
@@ -135,6 +147,7 @@ define(function (require) {
                     name: "function",
                     args: ["$val"],
                     modifier: "unnamed",
+                    level: 0,
                     isStatic: false,
                     line: 1
                 }, {
@@ -142,43 +155,105 @@ define(function (require) {
                     name: "myFunc",
                     args: [],
                     modifier: "public",
+                    level: 0,
                     isStatic: false,
                     line: 5
                 }, {
                     type: "function",
-                    name: "myFunc::function",
+                    name: "function",
                     args: ["$val"],
                     modifier: "unnamed",
+                    level: 1,
                     isStatic: false,
                     line: 6
                 }, {
                     type: "class",
-                    name: "::MyClass",
+                    name: "MyClass",
                     args: [],
                     modifier: "public",
+                    level: 0,
                     isStatic: false,
                     line: 11
                 }, {
                     type: "function",
-                    name: "MyClass::myFunc2",
+                    name: "myFunc2",
                     args: [],
                     modifier: "public",
+                    level: 1,
                     isStatic: false,
                     line: 12
                 }, {
                     type: "function",
-                    name: "MyClass::myFunc2::function",
+                    name: "function",
                     args: ["$val"],
                     modifier: "unnamed",
+                    level: 2,
                     isStatic: false,
                     line: 13
                 }, {
                     type: "function",
-                    name: "MyClass::myFunc3",
+                    name: "myFunc3",
                     args: [],
                     modifier: "public",
+                    level: 1,
                     isStatic: false,
                     line: 18
+                }
+            ]);
+        });
+
+        it("correctly returns the indentation level", function () {
+            var test = require("text!example/php/indentation_levels.php");
+            var result = Lexer.parse(test);
+            expect(result).toEqual([
+                {
+                    type: "function",
+                    name: "a",
+                    args: [],
+                    modifier: "public",
+                    level: 0,
+                    isStatic: false,
+                    line: 1
+                }, {
+                    type: "class",
+                    name: "MyClass",
+                    args: [],
+                    modifier: "public",
+                    level: 0,
+                    isStatic: false,
+                    line: 3
+                }, {
+                    type: "function",
+                    name: "b",
+                    args: [],
+                    modifier: "public",
+                    level: 1,
+                    isStatic: false,
+                    line: 4
+                }, {
+                    type: "function",
+                    name: "c",
+                    args: [],
+                    modifier: "public",
+                    level: 2,
+                    isStatic: false,
+                    line: 5
+                }, {
+                    type: "function",
+                    name: "function",
+                    args: ["$val"],
+                    modifier: "unnamed",
+                    level: 3,
+                    isStatic: false,
+                    line: 6
+                }, {
+                    type: "function",
+                    name: "d",
+                    args: [],
+                    modifier: "public",
+                    level: 1,
+                    isStatic: false,
+                    line: 11
                 }
             ]);
         });
@@ -200,6 +275,7 @@ define(function (require) {
                     name: "_flow",
                     args: [],
                     modifier: "public",
+                    level: 0,
                     isStatic: false,
                     line: 1
                 }, {
@@ -207,6 +283,7 @@ define(function (require) {
                     name: "ProcessAction",
                     args: ["$vars"],
                     modifier: "public",
+                    level: 0,
                     isStatic: false,
                     line: 6
                 }
@@ -219,16 +296,18 @@ define(function (require) {
             expect(result).toEqual([
                 {
                     type: "class",
-                    name: "::LogHelper",
+                    name: "LogHelper",
                     args: [],
                     modifier: "public",
+                    level: 0,
                     isStatic: false,
                     line: 6
                 }, {
                     type: "function",
-                    name: "LogHelper::LogToDB",
+                    name: "LogToDB",
                     args: ["$param1", "$param2", "$param3", "$param4"],
                     modifier: "public",
+                    level: 1,
                     isStatic: true,
                     line: 8
                 }
@@ -241,30 +320,34 @@ define(function (require) {
             expect(result).toEqual([
                 {
                     type: "class",
-                    name: "::BaseAdapter",
+                    name: "BaseAdapter",
                     args: [],
                     modifier: "public",
+                    level: 0,
                     isStatic: false,
                     line: 1
                 }, {
                     type: "function",
-                    name: "BaseAdapter::__construct",
+                    name: "__construct",
                     args: [],
                     modifier: "protected",
+                    level: 1,
                     isStatic: false,
                     line: 2
                 }, {
                     type: "function",
-                    name: "BaseAdapter::insertAlias",
+                    name: "insertAlias",
                     args: ["$alias", "$ormizer_id", "$referenced_table"],
                     modifier: "public",
+                    level: 1,
                     isStatic: false,
                     line: 12
                 }, {
                     type: "function",
-                    name: "BaseAdapter::castColumns",
+                    name: "castColumns",
                     args: ["$columns_array"],
                     modifier: "protected",
+                    level: 1,
                     isStatic: false,
                     line: 14
                 }

--- a/test/PHPLexerSpec.js
+++ b/test/PHPLexerSpec.js
@@ -144,35 +144,35 @@ define(function (require) {
                     modifier: "public",
                     isStatic: false,
                     line: 5
-                },{
+                }, {
                     type: "function",
                     name: "myFunc::function",
                     args: ["$val"],
                     modifier: "unnamed",
                     isStatic: false,
                     line: 6
-                },{
+                }, {
                     type: "class",
                     name: "::MyClass",
                     args: [],
                     modifier: "public",
                     isStatic: false,
                     line: 11
-                },{
+                }, {
                     type: "function",
                     name: "MyClass::myFunc2",
                     args: [],
                     modifier: "public",
                     isStatic: false,
                     line: 12
-                },{
+                }, {
                     type: "function",
                     name: "MyClass::myFunc2::function",
                     args: ["$val"],
                     modifier: "unnamed",
                     isStatic: false,
                     line: 13
-                },{
+                }, {
                     type: "function",
                     name: "MyClass::myFunc3",
                     args: [],

--- a/test/PHPLexerSpec.js
+++ b/test/PHPLexerSpec.js
@@ -125,6 +125,69 @@ define(function (require) {
                 }
             ]);
         });
+
+        it("detects anonymous functions, also within other functions", function () {
+            var test = require("text!example/php/anonymous_functions.php");
+            var result = Lexer.parse(test);
+            expect(result).toEqual([
+                {
+                    type: "function",
+                    name: "function",
+                    args: ["$val"],
+                    modifier: "unnamed",
+                    isStatic: false,
+                    line: 1
+                }, {
+                    type: "function",
+                    name: "myFunc",
+                    args: [],
+                    modifier: "public",
+                    isStatic: false,
+                    line: 5
+                },{
+                    type: "function",
+                    name: "myFunc::function",
+                    args: ["$val"],
+                    modifier: "unnamed",
+                    isStatic: false,
+                    line: 6
+                },{
+                    type: "class",
+                    name: "::MyClass",
+                    args: [],
+                    modifier: "public",
+                    isStatic: false,
+                    line: 11
+                },{
+                    type: "function",
+                    name: "MyClass::myFunc2",
+                    args: [],
+                    modifier: "public",
+                    isStatic: false,
+                    line: 12
+                },{
+                    type: "function",
+                    name: "MyClass::myFunc2::function",
+                    args: ["$val"],
+                    modifier: "unnamed",
+                    isStatic: false,
+                    line: 13
+                },{
+                    type: "function",
+                    name: "MyClass::myFunc3",
+                    args: [],
+                    modifier: "public",
+                    isStatic: false,
+                    line: 18
+                }
+            ]);
+        });
+
+        it("detects and ignore strings and execute operator", function () {
+            var test = require("text!example/php/strings.php");
+            var result = Lexer.parse(test);
+            expect(result.length).toEqual(0);
+        });
     });
 
     describe("PHP Lexer issues", function () {

--- a/test/example/php/anonymous_functions.php
+++ b/test/example/php/anonymous_functions.php
@@ -1,0 +1,20 @@
+<?php
+array_walk_recursive($array, function(&$val) {
+    $val = utf8_encode($val);
+});
+
+function myFunc() {
+    $closure = function(&$val) {
+        $val = utf8_encode($val);
+    };
+}
+
+class MyClass {
+    function myFunc2() {
+        array_walk_recursive($array, function(&$val) {
+            $val = utf8_encode($val);
+        });
+    }
+
+    function myFunc3() {}
+}

--- a/test/example/php/indentation_levels.php
+++ b/test/example/php/indentation_levels.php
@@ -1,0 +1,13 @@
+<?php
+function a() {}
+
+class MyClass {
+    function b() {
+        function c() {
+            $closure = function(&$val) {
+                $val = utf8_encode($val);
+            };
+        }
+    }
+    function d() {}
+}

--- a/test/example/php/strings.php
+++ b/test/example/php/strings.php
@@ -1,0 +1,4 @@
+<?php
+require_once("class.function/\"extends\".'interface'");
+$str2 = 'class "function"\'extends interface\'';
+$command = `class function \`extends\` interface`;


### PR DESCRIPTION
This PR fixes the problem with the implementation of multiple interfaces by detecting the ',' in the class declaration.

It also improves #73 and #74 solution through a new feature: detection of strings within the code. Both in single and double quotation marks.
This prevents errors with other reserved words that may appear in strings ('function', 'extends' ...) and avoid the dirty fix of putting a space behind 'class'.

@Hirse, you told me to look if you forgot any test. One that is missing is for the fix of anonymous functions within other functions that was in my previous PR. If you write it, you will realize that it fails. Within a class, the subsequent function to a function containing an anonymous one, loses the namespace.
I'm on it. But I think is best to send you these changes while I try to fix it.