### PR TITLE
Autohide feature.

### DIFF
--- a/main.js
+++ b/main.js
@@ -12,6 +12,7 @@ define(function (require, exports, module) {
     var prefs              = require("src/Preferences");
     var OutlineManager     = require("src/OutlineManager");
     var ToolbarButton      = require("src/ToolbarButton");
+    var Strings            = require("strings");
     /* eslint-enable no-multi-spaces *//* beautify preserve:end */
 
     ExtensionUtils.loadStyleSheet(module, "styles/styles.css");
@@ -41,7 +42,7 @@ define(function (require, exports, module) {
 
     /* beautify preserve:start *//* eslint-disable no-multi-spaces */
     var COMMAND_AUTOHIDE   = "outline.autohide";
-    var MENU_ITEM_AUTOHIDE = "Outline List Autohide";
+    var MENU_ITEM_AUTOHIDE = Strings.MENU_ITEM_AUTOHIDE;
     /* eslint-enable no-multi-spaces *//* beautify preserve:end */
 
     /**
@@ -95,7 +96,7 @@ define(function (require, exports, module) {
                 OutlineManager.updateOutline(document.getText());
                 OutlineManager.showOutline();
                 if (prefs.get("autohide")) {
-                    OutlineManager.enableAutohide();
+                    OutlineManager.toggleAutohide();
                 }
             }
         } else {
@@ -103,7 +104,7 @@ define(function (require, exports, module) {
             DocumentManager.off("documentSaved.outline-list", handleDocumentSave);
             OutlineManager.hideOutline();
             if (prefs.get("autohide")) {
-                OutlineManager.enableAutohide(false);
+                OutlineManager.toggleAutohide(false);
             }
         }
     }
@@ -113,7 +114,7 @@ define(function (require, exports, module) {
      */
     function handleSidebarChange() {
         if (prefs.get("autohide")) {
-            OutlineManager.enableAutohide(false);
+            OutlineManager.toggleAutohide(false);
         }
         if (prefs.get("sidebar")) {
             OutlineManager.setPosition(OutlineManager.POSITION_SIDEBAR);
@@ -121,7 +122,7 @@ define(function (require, exports, module) {
             OutlineManager.setPosition(OutlineManager.POSITION_TOOLBAR);
         }
         if (prefs.get("autohide")) {
-            OutlineManager.enableAutohide();
+            OutlineManager.toggleAutohide();
         }
     }
 
@@ -145,7 +146,7 @@ define(function (require, exports, module) {
 
     function handleAutohideChange() {
         if (prefs.get("autohide")) {
-            OutlineManager.enableAutohide();
+            OutlineManager.toggleAutohide();
             if (prefs.get("enabled")) {
                 OutlineManager.hideOutline();
                 if (!prefs.get("sidebar")) {
@@ -153,7 +154,7 @@ define(function (require, exports, module) {
                 }
             }
         } else {
-            OutlineManager.enableAutohide(false);
+            OutlineManager.toggleAutohide(false);
             if (prefs.get("enabled")) {
                 OutlineManager.showOutline();
             }

--- a/main.js
+++ b/main.js
@@ -8,8 +8,6 @@ define(function (require, exports, module) {
     var ExtensionUtils     = brackets.getModule("utils/ExtensionUtils");
     var CommandManager     = brackets.getModule("command/CommandManager");
     var Menus              = brackets.getModule("command/Menus");
-    var Commands           = brackets.getModule("command/Commands");
-    var AppInit            = brackets.getModule("utils/AppInit");
 
     var prefs              = require("src/Preferences");
     var OutlineManager     = require("src/OutlineManager");
@@ -102,7 +100,9 @@ define(function (require, exports, module) {
             EditorManager.off("activeEditorChange.outline-list", handleEditorChange);
             DocumentManager.off("documentSaved.outline-list", handleDocumentSave);
             OutlineManager.hideOutline();
-            if (prefs.get("autohide")) OutlineManager.enableAutohide(false);
+            if (prefs.get("autohide")) {
+                OutlineManager.enableAutohide(false);
+            }
         }
     }
 
@@ -110,13 +110,17 @@ define(function (require, exports, module) {
      * Change the position of the outline.
      */
     function handleSidebarChange() {
-        if (prefs.get("autohide")) OutlineManager.enableAutohide(false);
+        if (prefs.get("autohide")) {
+            OutlineManager.enableAutohide(false);
+        }
         if (prefs.get("sidebar")) {
             OutlineManager.setPosition(OutlineManager.POSITION_SIDEBAR);
         } else {
             OutlineManager.setPosition(OutlineManager.POSITION_TOOLBAR);
         }
-        if (prefs.get("autohide")) OutlineManager.enableAutohide();
+        if (prefs.get("autohide")) {
+            OutlineManager.enableAutohide();
+        }
     }
 
     /**
@@ -148,7 +152,9 @@ define(function (require, exports, module) {
             }
         } else {
             OutlineManager.enableAutohide(false);
-            if (prefs.get("enabled")) OutlineManager.showOutline();
+            if (prefs.get("enabled")) {
+                OutlineManager.showOutline();
+            }
         }
     }
 
@@ -166,7 +172,7 @@ define(function (require, exports, module) {
     // Update the position if the no-distractions/pure-code mode is turned on
     PreferencesManager.on("change", "noDistractions", function () {
         if (!prefs.get("sidebar")) {
-                OutlineManager.setPosition(OutlineManager.POSITION_TOOLBAR);
+            OutlineManager.setPosition(OutlineManager.POSITION_TOOLBAR);
         }
     });
 

--- a/main.js
+++ b/main.js
@@ -94,7 +94,9 @@ define(function (require, exports, module) {
                 OutlineManager.setOutlineProvider(languageMapping[document.getLanguage().getName()]);
                 OutlineManager.updateOutline(document.getText());
                 OutlineManager.showOutline();
-                if (prefs.get("autohide")) OutlineManager.enableAutohide();
+                if (prefs.get("autohide")) {
+                    OutlineManager.enableAutohide();
+                }
             }
         } else {
             EditorManager.off("activeEditorChange.outline-list", handleEditorChange);
@@ -186,5 +188,4 @@ define(function (require, exports, module) {
     menu.addMenuItem(COMMAND_AUTOHIDE);
 
     CommandManager.get(COMMAND_AUTOHIDE).setChecked(prefs.get("autohide"));
-
 });

--- a/main.js
+++ b/main.js
@@ -140,7 +140,12 @@ define(function (require, exports, module) {
     function handleAutohideChange() {
         if (prefs.get("autohide")) {
             OutlineManager.enableAutohide();
-            if (prefs.get("enabled")) OutlineManager.hideOutline();
+            if (prefs.get("enabled")) {
+                OutlineManager.hideOutline();
+                if (!prefs.get("sidebar")) {
+                    OutlineManager.showPlaceHolder();
+                }
+            }
         } else {
             OutlineManager.enableAutohide(false);
             if (prefs.get("enabled")) OutlineManager.showOutline();

--- a/nls/es/strings.js
+++ b/nls/es/strings.js
@@ -13,6 +13,8 @@ define({
     COMMAND_INDENT: "Indentar Entradas",
     COMMAND_AUTOHIDE: "Auto-ocultar",
 
+    MESSAGE_SYNTAX_ERROR: "Arregla los errores de sintaxis en el fichero para que se muestre el Outline.",
+
     PREF_ENABLED_NAME: "Outline - Habilitar",
     PREF_ENABLED_DESC: "Habilitar/Deshabilitar Outline List",
     PREF_UNNAMED_NAME: "Outline - Anónimas",
@@ -26,5 +28,7 @@ define({
     PREF_INDENT_NAME: "Outline - Indentar",
     PREF_INDENT_DESC: "Verdadero para indentar las entradas de Outline List",
     PREF_AUTOHIDE_NAME: "Outline - Auto-ocultar",
-    PREF_AUTOHIDE_DESC: "Verdadero para habilitar auto-ocultar de Outline List"
+    PREF_AUTOHIDE_DESC: "Verdadero para habilitar auto-ocultar de Outline List",
+
+    MENU_ITEM_AUTOHIDE: "Outline List Auto-ocultar"
 });

--- a/nls/es/strings.js
+++ b/nls/es/strings.js
@@ -10,6 +10,8 @@ define({
     COMMAND_SORT: "Ordenar funciones",
     COMMAND_UNNAMED: "Mostrar funciones anónimas",
     COMMAND_ARGS: "Mostrar argumentos",
+    COMMAND_INDENT: "Indentar Entradas",
+    COMMAND_AUTOHIDE: "Auto-ocultar",
 
     PREF_ENABLED_NAME: "Outline - Habilitar",
     PREF_ENABLED_DESC: "Habilitar/Deshabilitar Outline List",
@@ -20,5 +22,9 @@ define({
     PREF_SIDEBAR_NAME: "Outline - Barra lateral",
     PREF_SIDEBAR_DESC: "Marca para mostrar Outline List en la barra lateral bajo el arbol de archivos",
     PREF_SORT_NAME: "Outline - Ordenar",
-    PREF_SORT_DESC: "Marca para ordenar el contenido de Outline List"
+    PREF_SORT_DESC: "Marca para ordenar el contenido de Outline List",
+    PREF_INDENT_NAME: "Outline - Indentar",
+    PREF_INDENT_DESC: "Verdadero para indentar las entradas de Outline List",
+    PREF_AUTOHIDE_NAME: "Outline - Auto-ocultar",
+    PREF_AUTOHIDE_DESC: "Verdadero para habilitar auto-ocultar de Outline List"
 });

--- a/nls/root/strings.js
+++ b/nls/root/strings.js
@@ -11,6 +11,7 @@ define({
     COMMAND_UNNAMED: "Show Unnamed Functions",
     COMMAND_ARGS: "Show Arguments",
     COMMAND_INDENT: "Indent Entries",
+    COMMAND_AUTOHIDE: "AutoHide",
 
     MESSAGE_SYNTAX_ERROR: "Fix the SyntaxErrors in the file to show the Outline.",
 
@@ -25,5 +26,7 @@ define({
     PREF_SORT_NAME: "Outline - Sorting",
     PREF_SORT_DESC: "True to sort the entries in the Outline List",
     PREF_INDENT_NAME: "Outline - Indent",
-    PREF_INDENT_DESC: "True to indent the entries in the Outline List"
+    PREF_INDENT_DESC: "True to indent the entries in the Outline List",
+    PREF_AUTOHIDE_NAME: "Outline - AutoHide",
+    PREF_AUTOHIDE_DESC: "True to enable autohide of the Outline List"
 });

--- a/nls/root/strings.js
+++ b/nls/root/strings.js
@@ -28,5 +28,7 @@ define({
     PREF_INDENT_NAME: "Outline - Indent",
     PREF_INDENT_DESC: "True to indent the entries in the Outline List",
     PREF_AUTOHIDE_NAME: "Outline - AutoHide",
-    PREF_AUTOHIDE_DESC: "True to enable autohide of the Outline List"
+    PREF_AUTOHIDE_DESC: "True to enable autohide of the Outline List",
+
+    MENU_ITEM_AUTOHIDE: "Outline List AutoHide"
 });

--- a/src/OutlineManager.js
+++ b/src/OutlineManager.js
@@ -225,7 +225,7 @@ define(function (require, exports, module) {
         $placeHolder.css("right", toolbarPx + "px");
         $(".content").css("right", $placeHolder.width() + toolbarPx + "px");
 
-        $placeHolder.on("mouseenter", function () {
+        $placeHolder.on("mouseenter.outline", function () {
             showOutline();
         });
     }
@@ -237,7 +237,7 @@ define(function (require, exports, module) {
         var $placeHolder = $("#outline-placeholder");
         if ($placeHolder.length > 0) {
             var toolbarPx = $("#main-toolbar:visible").width() || 0;
-            $placeHolder.off("mouseenter");
+            $placeHolder.off(".outline");
             $placeHolder.remove();
             $(".content").css("right", toolbarPx + "px");
         }
@@ -255,11 +255,11 @@ define(function (require, exports, module) {
 
         if (enable) {
             if (position === POSITION_SIDEBAR) {
-                $("#sidebar").on("mouseenter", function () {
+                $("#sidebar").on("mouseenter.outline", function () {
                     showOutline();
                 });
             }
-            $content.on("mouseenter", function () {
+            $content.on("mouseenter.outline", function () {
                 hideOutline();
                 if (position === POSITION_TOOLBAR) {
                     showPlaceHolder();
@@ -268,7 +268,7 @@ define(function (require, exports, module) {
         } else {
             $content.off("mouseenter");
             if (position === POSITION_SIDEBAR) {
-                $("#sidebar").off("mouseenter");
+                $("#sidebar").off(".outline");
             } else {
                 hidePlaceHolder();
             }

--- a/src/OutlineManager.js
+++ b/src/OutlineManager.js
@@ -78,14 +78,6 @@ define(function (require, exports, module) {
     // AutoHide
     var $editorHolder = $("#editor-holder");
 
-    prefs.onChange("autohide", function () {
-        if (prefs.get("autohide")) {
-            $editorHolder.on("click", autohide);
-        } else {
-            $editorHolder.off("click", autohide);
-        }
-    });
-
     /**
      * Handler for autohide Outline List
      */
@@ -94,6 +86,14 @@ define(function (require, exports, module) {
             prefs.togglePref("enabled");
         }
     }
+
+    prefs.onChange("autohide", function () {
+        if (prefs.get("autohide")) {
+            $editorHolder.on("click", autohide);
+        } else {
+            $editorHolder.off("click", autohide);
+        }
+    });
 
     /**
      * Handler for a horizontal resize of the outline list.

--- a/src/OutlineManager.js
+++ b/src/OutlineManager.js
@@ -260,10 +260,6 @@ define(function (require, exports, module) {
                         showOutline();
                     }
                 });
-            } else {
-                if (prefs.get("enable")) {
-                    showPlaceHolder();
-                }
             }
             $content.on("mouseenter", function () {
                 if (prefs.get("enabled")) {

--- a/src/OutlineManager.js
+++ b/src/OutlineManager.js
@@ -250,7 +250,9 @@ define(function (require, exports, module) {
      * @param {boolean} enable True to enable, false to disable.
      */
     function enableAutohide(enable) {
-        enable = enable === undefined ? true : enable;
+        if (enable === undefined) {
+            enable = true;
+        }
         var $content = $(".content");
 
         if (enable) {

--- a/src/OutlineManager.js
+++ b/src/OutlineManager.js
@@ -75,6 +75,26 @@ define(function (require, exports, module) {
         }
     });
 
+    // AutoHide
+    var $editorHolder = $("#editor-holder");
+
+    prefs.onChange("autohide", function () {
+        if (prefs.get("autohide")) {
+            $editorHolder.on("click", autohide);
+        } else {
+            $editorHolder.off("click", autohide);
+        }
+    });
+
+    /**
+     * Handler for autohide Outline List
+     */
+    function autohide() {
+        if (prefs.get("enabled")) {
+            prefs.togglePref("enabled");
+        }
+    }
+
     /**
      * Handler for a horizontal resize of the outline list.
      */

--- a/src/OutlineManager.js
+++ b/src/OutlineManager.js
@@ -250,7 +250,7 @@ define(function (require, exports, module) {
      * @param {boolean} enable True to enable, false to disable.
      */
     function enableAutohide(enable) {
-        if (enable === undefined) {
+        if (typeof enable !== "boolean") {
             enable = true;
         }
         var $content = $(".content");

--- a/src/OutlineManager.js
+++ b/src/OutlineManager.js
@@ -76,75 +76,6 @@ define(function (require, exports, module) {
     });
 
     /**
-     * Show the Auto-hide place holder and enable its listener for mouse enter.
-     */
-    function showPlaceHolder() {
-        $(".main-view").append('<div id="outline-placeholder"></div>');
-        var $placeHolder = $("#outline-placeholder");
-        var toolbarPx = $("#main-toolbar:visible").width() || 0;
-        $placeHolder.css("width", "20px");
-        $placeHolder.css("right", toolbarPx + "px");
-        $(".content").css("right", $placeHolder.width() + toolbarPx + "px");
-
-        $placeHolder.on("mouseenter", function () {
-            if (prefs.get("enabled")) {
-                 showOutline();
-            }
-        });
-    }
-
-    /**
-     * Hide the Auto-hide place holder and disable its listener.
-     */
-    function hidePlaceHolder() {
-        var $placeHolder = $("#outline-placeholder");
-        if ($placeHolder.length > 0) {
-            var toolbarPx = $("#main-toolbar:visible").width() || 0;
-            $placeHolder.off("mouseenter");
-            $placeHolder.remove();
-            $(".content").css("right", toolbarPx + "px");
-        }
-    }
-
-    /**
-     * Enable/disable the Outline Auto-hide.
-     * @param {boolean} enable True to enable, false to disable.
-     */
-    function enableAutohide(enable) {
-        enable = (enable === undefined) ? true : enable;
-        var $content = $(".content");
-
-        if (enable) {
-            if (position === POSITION_SIDEBAR) {
-                $("#sidebar").on("mouseenter", function () {
-                    if (prefs.get("enabled")) {
-                        showOutline();
-                    }
-                });
-            } else {
-                if (prefs.get("enable")) {
-                    showPlaceHolder();
-                }
-            }
-            $content.on("mouseenter", function () {
-                if (prefs.get("enabled")) {
-                    hideOutline();
-                    if (position === POSITION_TOOLBAR) {
-                        showPlaceHolder();
-                    }
-                }
-            });
-        } else {
-            $content.off("mouseenter");
-            if (position === POSITION_SIDEBAR) {
-                $("#sidebar").off("mouseenter");
-            } else {
-                hidePlaceHolder();
-            }
-        }
-    }
-
-    /**
      * Handler for a horizontal resize of the outline list.
      */
     function resize() {
@@ -280,6 +211,75 @@ define(function (require, exports, module) {
             showOutline();
         } else {
             position = newPosition;
+        }
+    }
+
+    /**
+     * Show the Auto-hide place holder and enable its listener for mouse enter.
+     */
+    function showPlaceHolder() {
+        $(".main-view").append('<div id="outline-placeholder"></div>');
+        var $placeHolder = $("#outline-placeholder");
+        var toolbarPx = $("#main-toolbar:visible").width() || 0;
+        $placeHolder.css("width", "20px");
+        $placeHolder.css("right", toolbarPx + "px");
+        $(".content").css("right", $placeHolder.width() + toolbarPx + "px");
+
+        $placeHolder.on("mouseenter", function () {
+            if (prefs.get("enabled")) {
+                 showOutline();
+            }
+        });
+    }
+
+    /**
+     * Hide the Auto-hide place holder and disable its listener.
+     */
+    function hidePlaceHolder() {
+        var $placeHolder = $("#outline-placeholder");
+        if ($placeHolder.length > 0) {
+            var toolbarPx = $("#main-toolbar:visible").width() || 0;
+            $placeHolder.off("mouseenter");
+            $placeHolder.remove();
+            $(".content").css("right", toolbarPx + "px");
+        }
+    }
+
+    /**
+     * Enable/disable the Outline Auto-hide.
+     * @param {boolean} enable True to enable, false to disable.
+     */
+    function enableAutohide(enable) {
+        enable = (enable === undefined) ? true : enable;
+        var $content = $(".content");
+
+        if (enable) {
+            if (position === POSITION_SIDEBAR) {
+                $("#sidebar").on("mouseenter", function () {
+                    if (prefs.get("enabled")) {
+                        showOutline();
+                    }
+                });
+            } else {
+                if (prefs.get("enable")) {
+                    showPlaceHolder();
+                }
+            }
+            $content.on("mouseenter", function () {
+                if (prefs.get("enabled")) {
+                    hideOutline();
+                    if (position === POSITION_TOOLBAR) {
+                        showPlaceHolder();
+                    }
+                }
+            });
+        } else {
+            $content.off("mouseenter");
+            if (position === POSITION_SIDEBAR) {
+                $("#sidebar").off("mouseenter");
+            } else {
+                hidePlaceHolder();
+            }
         }
     }
 

--- a/src/OutlineManager.js
+++ b/src/OutlineManager.js
@@ -218,7 +218,7 @@ define(function (require, exports, module) {
      * Show the Auto-hide place holder and enable its listener for mouse enter.
      */
     function showPlaceHolder() {
-        $(".main-view").append('<div id="outline-placeholder"></div>');
+        $(".main-view").append("<div id=\"outline-placeholder\"></div>");
         var $placeHolder = $("#outline-placeholder");
         var toolbarPx = $("#main-toolbar:visible").width() || 0;
         $placeHolder.css("width", "20px");
@@ -227,7 +227,7 @@ define(function (require, exports, module) {
 
         $placeHolder.on("mouseenter", function () {
             if (prefs.get("enabled")) {
-                 showOutline();
+                showOutline();
             }
         });
     }
@@ -250,7 +250,7 @@ define(function (require, exports, module) {
      * @param {boolean} enable True to enable, false to disable.
      */
     function enableAutohide(enable) {
-        enable = (enable === undefined) ? true : enable;
+        enable = enable === undefined ? true : enable;
         var $content = $(".content");
 
         if (enable) {

--- a/src/OutlineManager.js
+++ b/src/OutlineManager.js
@@ -247,7 +247,7 @@ define(function (require, exports, module) {
      * Enable/disable the Outline Auto-hide.
      * @param {boolean} enable True to enable, false to disable.
      */
-    function enableAutohide(enable) {
+    function toggleAutohide(enable) {
         if (typeof enable !== "boolean") {
             enable = true;
         }
@@ -282,7 +282,7 @@ define(function (require, exports, module) {
         updateOutline: updateOutline,
         showOutline: showOutline,
         hideOutline: hideOutline,
-        enableAutohide: enableAutohide,
+        toggleAutohide: toggleAutohide,
         showPlaceHolder: showPlaceHolder,
         POSITION_SIDEBAR: POSITION_SIDEBAR,
         POSITION_TOOLBAR: POSITION_TOOLBAR

--- a/src/OutlineManager.js
+++ b/src/OutlineManager.js
@@ -82,6 +82,7 @@ define(function (require, exports, module) {
         $(".main-view").append('<div id="outline-placeholder"></div>');
         var $placeHolder = $("#outline-placeholder");
         var toolbarPx = $("#main-toolbar:visible").width() || 0;
+        $placeHolder.css("width", "20px");
         $placeHolder.css("right", toolbarPx + "px");
         $(".content").css("right", $placeHolder.width() + toolbarPx + "px");
 

--- a/src/OutlineManager.js
+++ b/src/OutlineManager.js
@@ -75,25 +75,38 @@ define(function (require, exports, module) {
         }
     });
 
-    // AutoHide
-    var $editorHolder = $("#editor-holder");
-
     /**
-     * Handler for autohide Outline List
+     * Enable/disable the Outline auto-hide.
+     * @param {boolean} enable True to enable, false to disable.
      */
-    function autohide() {
-        if (prefs.get("enabled")) {
-            prefs.togglePref("enabled");
+    function enableAutohide(enable) {
+        enable = (enable === undefined) ? true : enable;
+
+        var $content = $(".content");
+        var $unhideArea;
+
+        if (position === POSITION_SIDEBAR) {
+            $unhideArea = $("#sidebar");
+        } else {
+            $unhideArea = $("#main-toolbar");
+        }
+
+        if (enable) {
+            $content.on("mouseenter", function () {
+                if (prefs.get("enabled")) {
+                    hideOutline();
+                }
+            });
+            $unhideArea.on("mouseenter", function () {
+                if (prefs.get("enabled")) {
+                    showOutline();
+                }
+            });
+        } else {
+            $content.off("mouseenter");
+            $unhideArea.off("mouseenter");
         }
     }
-
-    prefs.onChange("autohide", function () {
-        if (prefs.get("autohide")) {
-            $editorHolder.on("click", autohide);
-        } else {
-            $editorHolder.off("click", autohide);
-        }
-    });
 
     /**
      * Handler for a horizontal resize of the outline list.
@@ -241,6 +254,7 @@ define(function (require, exports, module) {
         updateOutline: updateOutline,
         showOutline: showOutline,
         hideOutline: hideOutline,
+        enableAutohide: enableAutohide,
         POSITION_SIDEBAR: POSITION_SIDEBAR,
         POSITION_TOOLBAR: POSITION_TOOLBAR
     };

--- a/src/OutlineManager.js
+++ b/src/OutlineManager.js
@@ -226,9 +226,7 @@ define(function (require, exports, module) {
         $(".content").css("right", $placeHolder.width() + toolbarPx + "px");
 
         $placeHolder.on("mouseenter", function () {
-            if (prefs.get("enabled")) {
-                showOutline();
-            }
+            showOutline();
         });
     }
 
@@ -258,17 +256,13 @@ define(function (require, exports, module) {
         if (enable) {
             if (position === POSITION_SIDEBAR) {
                 $("#sidebar").on("mouseenter", function () {
-                    if (prefs.get("enabled")) {
-                        showOutline();
-                    }
+                    showOutline();
                 });
             }
             $content.on("mouseenter", function () {
-                if (prefs.get("enabled")) {
-                    hideOutline();
-                    if (position === POSITION_TOOLBAR) {
-                        showPlaceHolder();
-                    }
+                hideOutline();
+                if (position === POSITION_TOOLBAR) {
+                    showPlaceHolder();
                 }
             });
         } else {

--- a/src/OutlineManager.js
+++ b/src/OutlineManager.js
@@ -76,35 +76,70 @@ define(function (require, exports, module) {
     });
 
     /**
-     * Enable/disable the Outline auto-hide.
+     * Show the Auto-hide place holder and enable its listener for mouse enter.
+     */
+    function showPlaceHolder() {
+        $(".main-view").append('<div id="outline-placeholder"></div>');
+        var $placeHolder = $("#outline-placeholder");
+        var toolbarPx = $("#main-toolbar:visible").width() || 0;
+        $placeHolder.css("right", toolbarPx + "px");
+        $(".content").css("right", $placeHolder.width() + toolbarPx + "px");
+
+        $placeHolder.on("mouseenter", function () {
+            if (prefs.get("enabled")) {
+                 showOutline();
+            }
+        });
+    }
+
+    /**
+     * Hide the Auto-hide place holder and disable its listener.
+     */
+    function hidePlaceHolder() {
+        var $placeHolder = $("#outline-placeholder");
+        if ($placeHolder.length > 0) {
+            var toolbarPx = $("#main-toolbar:visible").width() || 0;
+            $placeHolder.off("mouseenter");
+            $placeHolder.remove();
+            $(".content").css("right", toolbarPx + "px");
+        }
+    }
+
+    /**
+     * Enable/disable the Outline Auto-hide.
      * @param {boolean} enable True to enable, false to disable.
      */
     function enableAutohide(enable) {
         enable = (enable === undefined) ? true : enable;
-
         var $content = $(".content");
-        var $unhideArea;
-
-        if (position === POSITION_SIDEBAR) {
-            $unhideArea = $("#sidebar");
-        } else {
-            $unhideArea = $("#main-toolbar");
-        }
 
         if (enable) {
+            if (position === POSITION_SIDEBAR) {
+                $("#sidebar").on("mouseenter", function () {
+                    if (prefs.get("enabled")) {
+                        showOutline();
+                    }
+                });
+            } else {
+                if (prefs.get("enable")) {
+                    showPlaceHolder();
+                }
+            }
             $content.on("mouseenter", function () {
                 if (prefs.get("enabled")) {
                     hideOutline();
-                }
-            });
-            $unhideArea.on("mouseenter", function () {
-                if (prefs.get("enabled")) {
-                    showOutline();
+                    if (position === POSITION_TOOLBAR) {
+                        showPlaceHolder();
+                    }
                 }
             });
         } else {
             $content.off("mouseenter");
-            $unhideArea.off("mouseenter");
+            if (position === POSITION_SIDEBAR) {
+                $("#sidebar").off("mouseenter");
+            } else {
+                hidePlaceHolder();
+            }
         }
     }
 
@@ -255,6 +290,7 @@ define(function (require, exports, module) {
         showOutline: showOutline,
         hideOutline: hideOutline,
         enableAutohide: enableAutohide,
+        showPlaceHolder: showPlaceHolder,
         POSITION_SIDEBAR: POSITION_SIDEBAR,
         POSITION_TOOLBAR: POSITION_TOOLBAR
     };

--- a/src/Preferences.js
+++ b/src/Preferences.js
@@ -72,8 +72,7 @@ define(function (require, exports, module) {
             options: {
                 name: Strings.PREF_AUTOHIDE_NAME,
                 description: Strings.PREF_AUTOHIDE_DESC
-            },
-            inContextMenu: false
+            }
         }
     ];
 

--- a/src/Preferences.js
+++ b/src/Preferences.js
@@ -65,6 +65,15 @@ define(function (require, exports, module) {
                 description: Strings.PREF_INDENT_DESC
             },
             inContextMenu: true
+        }, {
+            id: "autohide",
+            type: "boolean",
+            value: true,
+            options: {
+                name: Strings.PREF_AUTOHIDE_NAME,
+                description: Strings.PREF_AUTOHIDE_DESC
+            },
+            inContextMenu: true
         }
     ];
 

--- a/src/Preferences.js
+++ b/src/Preferences.js
@@ -68,12 +68,12 @@ define(function (require, exports, module) {
         }, {
             id: "autohide",
             type: "boolean",
-            value: true,
+            value: false,
             options: {
                 name: Strings.PREF_AUTOHIDE_NAME,
                 description: Strings.PREF_AUTOHIDE_DESC
             },
-            inContextMenu: true
+            inContextMenu: false
         }
     ];
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -104,7 +104,6 @@
 
 #outline-placeholder {
     border-top: 1px solid rgba(255, 255, 255, 0.05);
-    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
     background-color: #47484b;
     bottom: 0;
     position: absolute;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -102,6 +102,16 @@
     padding-left: 14px;
 }
 
+#outline-placeholder {
+    border-top: 1px solid rgba(255, 255, 255, 0.05);
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
+    background-color: #47484b;
+    bottom: 0;
+    width: 20px;
+    position: absolute;
+    top: 0;
+}
+
 
 /* ==== Outline Entries ==== */
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -107,7 +107,6 @@
     text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
     background-color: #47484b;
     bottom: 0;
-    width: 20px;
     position: absolute;
     top: 0;
 }


### PR DESCRIPTION
Hi.

This PR adds the AutoHide feature, similar to the one described in the old issue #17.

This works by adding an entry in the preferences context menu to enable/disable the feature.

When enabled, clicking on the editor results in hidding the Outline List.
To unhide it relies on the default behavior of the extension: click on the button on main toolbar.

Greetings.