### PR TITLE
Autohide fixes.

### DIFF
--- a/main.js
+++ b/main.js
@@ -155,9 +155,10 @@ define(function (require, exports, module) {
         var document = DocumentManager.getCurrentDocument();
         if (prefs.get("autohide") && isOutlineAvailable(document)) {
             Autohide.enable();
-        } else if (prefs.get("autohide") && !isOutlineAvailable(document)) {
+        } else if (!prefs.get("autohide") && !isOutlineAvailable(document)) {
+            Autohide.disable();
             OutlineManager.hideOutline();
-        } else {
+        } else if (!prefs.get("autohide") && isOutlineAvailable(document)) {
             Autohide.disable();
         }
     }

--- a/main.js
+++ b/main.js
@@ -68,6 +68,9 @@ define(function (require, exports, module) {
                     OutlineManager.showOutline();
                 }
             } else {
+                if (prefs.get("autohide")) {
+                    Autohide.disable();
+                }
                 OutlineManager.hideOutline();
             }
         }, 100);
@@ -149,8 +152,11 @@ define(function (require, exports, module) {
     }
 
     function handleAutohideChange() {
-        if (prefs.get("autohide")) {
+        var document = DocumentManager.getCurrentDocument();
+        if (prefs.get("autohide") && isOutlineAvailable(document)) {
             Autohide.enable();
+        } else if (prefs.get("autohide") && !isOutlineAvailable(document)) {
+            OutlineManager.hideOutline();
         } else {
             Autohide.disable();
         }


### PR DESCRIPTION
This PR fixes small problems related to the Autohide feature:

It prevents both the placeholder and an erroneous outline list corresponding to the last valid one from being displayed, when the type of the document is not supported by the extension.

And it makes the autohide have the same default behavior of the extension of not showing anything in this case.

PD: I hope not to make you work as much as in my previous PR, @Hirse.